### PR TITLE
Guard against zero blocks on a rank in diffusion

### DIFF
--- a/src/radiation_diffusion/diffusion_equation.hpp
+++ b/src/radiation_diffusion/diffusion_equation.hpp
@@ -46,6 +46,10 @@ CalculateFluxes(std::shared_ptr<parthenon::MeshData<Real>> &md_mat,
   auto pack = desc.GetPack(md.get());
   auto pack_mat = desc_mat.GetPack(md_mat.get());
 
+  // On a two-level composite multigrid grid, SparsePack selects only the fine,
+  // active blocks. A rank can therefore have MeshData but no blocks in this pack.
+  if (pack.GetNBlocks() == 0) return TaskStatus::complete;
+
   for (int dim = 0; dim < ndim; ++dim) {
     const auto te = dim == 0 ? TE::F1 : (dim == 1 ? TE::F2 : TE::F3);
     // The diffusion coefficient arrays are cell mem aligned
@@ -94,6 +98,8 @@ FluxMultiplyMatrix(std::shared_ptr<parthenon::MeshData<Real>> &md_mat,
       parthenon::MakePackDescriptor<face_area, DeltaX, volume>(md_mat.get());
   auto pack_mat = desc_mat.GetPack(md_mat.get());
 
+  if (pack_in.GetNBlocks() == 0) return TaskStatus::complete;
+
   using TE = parthenon::TopologicalElement;
   using lt = RiotUtils::LoopType<>;
   auto idx_space = lt::GetIndexSpace(IndexDomain::interior, 0, pack_in.GetNBlocks(),
@@ -140,6 +146,11 @@ CalculateLocalLinear(std::shared_ptr<parthenon::MeshData<Real>> &md_mat,
   auto pack_mat = desc_mat.GetPack(md_mat.get());
   auto pack_in = desc.GetPack(md_in.get());
   auto pack_out = desc.GetPack(md_out.get());
+
+  // GetSizeHost(0, ...) is invalid for an empty selected pack. This occurs on
+  // ranks that own no active fine blocks of a two-level composite grid.
+  if (pack_in.GetNBlocks() == 0) return TaskStatus::complete;
+
   const int ngroup = pack_in.GetSizeHost(0, var_t());
 
   using lt = RiotUtils::LoopType<>;
@@ -187,6 +198,8 @@ CorrectRefinementBoundaryFluxes(std::shared_ptr<parthenon::MeshData<Real>> &md) 
   static const auto desc =
       parthenon::MakePackDescriptor<var_t>(md.get(), {}, {PDOpt::WithFluxes});
   auto pack = desc.GetPack(md.get());
+  if (pack.GetNBlocks() == 0) return TaskStatus::complete;
+
   const std::size_t scratch_size_in_bytes = 0;
   const std::size_t scratch_level = 1;
 
@@ -258,6 +271,8 @@ inline parthenon::TaskStatus Scale(std::shared_ptr<parthenon::MeshData<Real>> &m
   auto desc = parthenon::MakePackDescriptor<var_t>(md.get());
   auto pack = desc.GetPack(md.get());
   auto pack_matrix = desc.GetPack(md_matrix.get());
+  if (pack.GetNBlocks() == 0) return TaskStatus::complete;
+
   IndexRange ib = md->GetBoundsI(IndexDomain::interior);
   IndexRange jb = md->GetBoundsJ(IndexDomain::interior);
   IndexRange kb = md->GetBoundsK(IndexDomain::interior);
@@ -369,6 +384,8 @@ class LinearizedRadiationDiffusionEquation {
     static auto desc = parthenon::MakePackDescriptor<var_t>(md_diag.get());
     auto pack = desc.GetPack(md_diag.get());
     auto pack_mat = desc_mat.GetPack(md_mat.get());
+
+    if (pack.GetNBlocks() == 0) return TaskStatus::complete;
 
     using TE = parthenon::TopologicalElement;
     using lt = RiotUtils::LoopType<LoopConstraint::NoGhost>;

--- a/src/radiation_diffusion/multigroup_diffusion-package.cpp
+++ b/src/radiation_diffusion/multigroup_diffusion-package.cpp
@@ -606,6 +606,8 @@ void MultiGroup<temperature>::MeshPostProblemGenerator(parthenon::Mesh *mesh,
   static const auto desc = parthenon::MakePackDescriptor<temperature, Egroup>(md);
   auto pack = desc.GetPack(md);
 
+  if (pack.GetNBlocks() == 0) return;
+
   Multiphysics::FillInteriorDerived(md);
 
   BlackBodyHelper bb_helper(md->GetMeshPointer());


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "fix bug in mix.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary
In some cases for larger problems with multigrid, you can hit situations where a rank has no blocks.  This adds guards for blocks < ranks (checks for early exit in a couple of routines).
<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Format your changes by using the `scripts/format.sh` command or by using `@par-hermes format`
- [ ] Document any new features, update documentation for changes made.
- [ ] Make sure the copyright notice on any files you modified is up to date.
- [ ] LANL employees: make sure tests pass both on the github CI and on the re-git CI
- [ ] If ML was used, make sure to add a disclaimer at the top of a file indicating ML was used to assist in generating the file.
- [ ] If Agentic AI was used, have the AI generate a "proposed changes" markdown file and store it in the `plan_histories` folder, with a filename the same as the MR number.

If preparing for a new release, in addition please check the following:
- [ ] Update the version in cmake.
